### PR TITLE
Remove unnecessary arrow icon classes

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1125,7 +1125,7 @@
                 html += '<th></th>';
 
             if (!minDate || minDate.isBefore(calendar.firstDay)) {
-                html += '<th class="prev available"><i class="fa fa-arrow-left icon icon-arrow-left glyphicon glyphicon-arrow-left"></i></th>';
+                html += '<th class="prev available"><i class="fa fa-arrow-left"></i></th>';
             } else {
                 html += '<th></th>';
             }
@@ -1138,7 +1138,7 @@
 
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';
             if (!maxDate || maxDate.isAfter(calendar.lastDay)) {
-                html += '<th class="next available"><i class="fa fa-arrow-right icon icon-arrow-right glyphicon glyphicon-arrow-right"></i></th>';
+                html += '<th class="next available"><i class="fa fa-arrow-right"></i></th>';
             } else {
                 html += '<th></th>';
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26662725/51906638-daa02000-23c4-11e9-9cf2-76d863495b62.png)


Remove icon classes ( `icon icon-arrow-left glyphicon glyphicon-arrow-left`), for avoiding overwriting `Fontawesome` icon styles. 